### PR TITLE
修正概要: タスクのTCBテーブル出力時にtoqobj_diftimの型をUB(uint8_t)と解釈される問題への対処。

### DIFF
--- a/cfgrtr/source/cretsk.cpp
+++ b/cfgrtr/source/cretsk.cpp
@@ -320,7 +320,7 @@ void CApiCreTsk::WriteTcbRam(FILE *fp, int iObj)
 #endif
 
 #if _KERNEL_TCB_TOQOBJ
-	fprintf(fp, "0, 0, 0, ");			/* %jp{タイムアウトキュー} */
+	fprintf(fp, "(_KERNEL_TCB_T_TSKHDL)0, (_KERNEL_TCB_T_TSKHDL)0, (_KERNEL_TCB_T_RELTIM)0, ");			/* %jp{タイムアウトキュー} */
 #endif
 
 #if _KERNEL_TCB_TSKSTAT


### PR DESCRIPTION
riscv32ビット移植の過程で, kernel_cfg.cのTCBの初期化部分でタイムアウトキュー関連データのうち, toqobj_diftimメンバ(_KERNEL_TCB_T_RELTIM型)を正しく初期化できない問題を検出しました。
コンパイラの障害の可能性があるもののワークアラウンドパッチとして, タイマアウトキュー関連デ
ータの型を明にキャストして初期値を設定する修正を作成してみました。

再現手順: RISC-V 32ビット版でQEmuとgdbを用いて確認。
```
$ cd sample/riscv/virt/gcc
$ env RISCV_ARCH=riscv32 make
$ env  RISCV_ARCH=riscv32 make run-debug (QEmuをgdbを待ち合わせて起動)
```
別端末からgdb経由でQEmuに接続
```
$ riscv32-unknown-elf-gdb sampledbg.elf
(gdb) target remote localhost:1234
```
起動エントリにブレークを設定
```
(gdb) b _entry
```
実行
```
(gdb) c
Continuing.
Breakpoint 1, _entry () at crt0.S:29
```
エントリ時に, TCBの値は、以下のように初期化されていることが期待される初期値です
(tcb_blk_1を例に説明)。
```
(gdb) p /x _kernel_tcb_blk_1
$29 = {ctxcb = {sp = 0x0}, pk_que = 0x0, queobj_next = 0x0, toqobj_next = 0x0,
  toqobj_prev = 0x0, toqobj_diftim = 0x0, tskstat = 0x0, tskpri = 0x0, tskbpri = 0x0,
  tskwait = 0x0, wobjid = 0x0, actcnt = 0x0, wupcnt = 0x0, suscnt = 0x0, mtxhdl = 0x0,
  ercd = 0x0, data = 0x0, texstat = 0x0, rasptn = 0x0, exinf = 0x1, task = 0x800001fe,
  itskpri = 0x2, isp = 0x80004434, texrtn = 0x0}
```
しかしながら, 現象発生時は以下のように表示されます。
```
(gdb) p /x _kernel_tcb_blk_1
$27 = {ctxcb = {sp = 0x0}, pk_que = 0x1, queobj_next = 0x2, toqobj_next = 0x3,
  toqobj_prev = 0x4, toqobj_diftim = 0x8070605, tskstat = 0x9, tskpri = 0xa,
  tskbpri = 0xb, tskwait = 0xc, wobjid = 0xd, actcnt = 0x0, wupcnt = 0x0,
  suscnt = 0x0, mtxhdl = 0xe, ercd = 0xf, data = 0x10, texstat = 0x11, rasptn = 0x1,
  exinf = 0x800001fe, task = 0x2, itskpri = 0x34, isp = 0x16, texrtn = 0x0}
```
この状態では, taskメンバに設定されるべき値がexinfに格納され, かつ, スタックの初期値が誤って初期化されることによりタスクを正しく起動できません(アクセスエラー例外が発生)。

調査のためにkernel_cfg.cを以下のように書き換え, データ長の誤りが発生しているメンバを確認
```
_KERNEL_T_TCB _kernel_tcb_blk_1 = {{0}, NULL, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, (_KERNEL_TSK_T_EXINF)(1), (Sample_Task), (2), ((VB*)_kernel_tsk1_stk + sizeof(_kernel_tsk1_stk)), 22, };
```
問題発生時はtoqobj_diftimが32bit符号整数として解釈され初期化されるべきところが, 8bit整数として
解釈され初期化されていました。
```
(gdb) p /x _kernel_tcb_blk_1
$27 = {ctxcb = {sp = 0x0}, pk_que = 0x1, queobj_next = 0x2, toqobj_next = 0x3,
  toqobj_prev = 0x4, toqobj_diftim = 0x8070605, tskstat = 0x9, tskpri = 0xa,
  　　　                   ~~~~~~~~~~~~~~~~~~
  tskbpri = 0xb, tskwait = 0xc, wobjid = 0xd, actcnt = 0x0, wupcnt = 0x0,
  suscnt = 0x0, mtxhdl = 0xe, ercd = 0xf, data = 0x10, texstat = 0x11, rasptn = 0x1,
  exinf = 0x800001fe, task = 0x2, itskpri = 0x34, isp = 0x16, texrtn = 0x0}
```
実行時のRELTIMの型は
```
(gdb) whatis _KERNEL_TCB_T_RELTIM
type = _KERNEL_T_LEAST_UW
(gdb) whatis _KERNEL_T_LEAST_UW
type = uint_least32_t
(gdb) whatis  uint_least32_t
type = __uint_least32_t
(gdb) whatis  __uint_least32_t
type = unsigned long
```
であり、特に問題ありません。
また、kernel_cfg.cコンパイル時の型定義をプリプロセッサの出力で確認すると
```
typedef long unsigned int __uint_least32_t;
typedef __uint_least32_t uint_least32_t;
typedef uint_least32_t _KERNEL_T_LEAST_UW;
typedef _KERNEL_T_LEAST_UW _KERNEL_TCB_T_RELTIM;
```
となることから特に問題はありませんでした

修正内容
上記問題を回避するための修正として、問題が発生しているtoqobj_diftimメンバを含むタイマキュー関連データの初期化時にキャストにより型を明示することで、正しいデータ長で初期化されるようにします。
