### PR TITLE
修正概要: GCC使用時の依存関係生成処理をクロスコンパイラを使用して実施するように修正.

### DIFF
--- a/kernel/build/common/gmake/common.inc
+++ b/kernel/build/common/gmake/common.inc
@@ -23,7 +23,7 @@ CMD_RMDIR  ?= rmdir
 CMD_CP     ?= cp
 CMD_MV     ?= mv
 CMD_RM     ?= rm -f
-CMD_DEPEND ?= gcc
+CMD_DEPEND ?= $(GCC_ARCH)gcc
 CMD_CPP    ?= cpp
 
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
GCC使用時の依存関係生成処理をクロスコンパイラを使用して実施するように修正しました。

sampleプログラム作成時にクロスコンパイラを使った依存関係が生成されることまでは確認しています。
各ターゲットの構築時のログをbuild.logとして保存して
grepでログを確認しました。
```
arm/aduc7000/gcc/build.log:arm-elf-gcc -MM -I../../../
arm/lpc1114/gcc/build.log:arm-none-eabi-gcc -MM -I../.
arm/lpc2000/gcc/build.log:arm-elf-gcc -MM -I../../../.
arm/stm32f103/gcc/build.log:arm-none-eabi-gcc -MM -I..
arm/zynq7000/gcc/build.log:arm-none-eabi-gcc -MM -I../
arm/zynqmp_rpu/gcc/build.log:arm-none-eabi-gcc -MM -I.
h8/h83069/gcc/build.log:h8300-elf-gcc -MM -I../../../.
ia32/pcat/gcc/build.log:i386-elf-gcc -MM -I../../../..
mb/mb_v8_axi/gcc/build.log:mb-gcc -MM -I../../../../..
mb/smm/gcc/build.log:mb-gcc -MM -I../../../../../kerne
mips/jelly/gcc/build.log:mips-elf-gcc -MM -I../../../.
riscv/virt/gcc/build.log:riscv64-unknown-elf-gcc -MM -
sh/sh7144/gcc/build.log:sh-elf-gcc -MM -I../../../../.
sh/sh7262/gcc/build.log:sh-elf-gcc -MM -I../../../../.
```