### PR TITLE
修正概要: 末尾の空白を削除, ターゲット名の誤り(kernel_cleanとするべきところをclean_kernelとしていた)を修正。

### DIFF
--- a/sample/h8/h83069/gcc/Makefile
+++ b/sample/h8/h83069/gcc/Makefile
@@ -37,7 +37,7 @@ C_DEFS        += _RAM
 else
 # %jp{ROM焼きする場合}
 LINKER_SCRIPT ?= link_rom.lds
-C_DEFS        += 
+C_DEFS        +=
 endif
 
 
@@ -98,7 +98,7 @@ clean: makeexe_clean
 
 
 .PHONY : mostlyclean
-mostlyclean: clean clean_kernel
+mostlyclean: clean kernel_clean
 
 
 ../kernel_cfg.c ../kernel_id.h: ../system.cfg
@@ -121,4 +121,3 @@ $(OBJS_DIR)/sample.$(EXT_OBJ): ../sample.c ../kernel_id.h
 
 
 # end of file
-


### PR DESCRIPTION
H8のsampleプログラムのMakefile 中のkernel_cleanターゲットがclean_kernelになっていた問題を修正しました。
