### PR TITLE
IA32ポートの軽微なバグフィックス

### DIFF
--- a/kernel/source/arch/proc/ia32/i386/gcc/koutpw.S
+++ b/kernel/source/arch/proc/ia32/i386/gcc/koutpw.S
@@ -21,7 +21,7 @@
 _kernel_outpw:
 				movl	4(%esp), %edx
 				movl	8(%esp), %eax
-				outb	%eax, %dx
+				outl	%eax, %dx
 				ret
 
 

--- a/sample/ia32/pcat/gcc/Makefile
+++ b/sample/ia32/pcat/gcc/Makefile
@@ -140,10 +140,23 @@ ipl.bin: $(OBJS_DIR)/ipl.o
 $(TARGET).img: ipl.bin $(TARGET_BIN)
 	./fd_img.pl $(TARGET).img ipl.bin $(TARGET_BIN)
 
+# %jP{Bochsによる実行}%en{Run a program with Bochs}
 .PHONY : bochs
 bochs: $(TARGET).img
 	bochs "floppya: 1_44=$(TARGET).img, status=inserted" "boot: a"
 
+# %jP{QEmuによる実行}%en{Run a program with QEmu}
+.PHONY : qemu
+qemu: $(TARGET).img
+	qemu-system-i386 -boot a \
+	-drive file=sample.img,format=raw,if=floppy,media=disk,readonly=off,index=0
+
+# %jP{QEmuとGDBによるデバッグ実行}%en{Debug a program with QEmu and GDB}
+.PHONY : qemu-debug
+qemu-debug: $(TARGET).img
+	qemu-system-i386 -boot a \
+	-drive file=sample.img,format=raw,if=floppy,media=disk,readonly=off,index=0 \
+	-gdb tcp::1234
 
 # %jp{実行ファイル生成用設定読込み}%en{rules for exection file}
 include $(KERNEL_MAKINC_DIR)/makexe_r.inc

--- a/sample/ia32/pcat/gcc/Makefile
+++ b/sample/ia32/pcat/gcc/Makefile
@@ -27,6 +27,8 @@ CMD_OBJCNV ?= $(GCC_ARCH)objcopy
 ARCH_NAME ?= pcat
 ARCH_CC   ?= gcc
 
+ARCH_PROC ?= ia32/i386
+
 
 # %jp{ディレクトリ定義}
 TOP_DIR           = ../../../..
@@ -35,6 +37,7 @@ KERNEL_CFGRTR_DIR = $(TOP_DIR)/cfgrtr/build/gcc
 KERNEL_MAKINC_DIR = $(KERNEL_DIR)/build/common/gmake
 KERNEL_BUILD_DIR  = $(KERNEL_DIR)/build/ia32/pcat/gcc
 
+INC_PROC_DIR       = $(KERNEL_DIR)/include/arch/proc/$(ARCH_PROC)
 
 # %jp{コンフィギュレータ定義}
 KERNEL_CFGRTR = $(KERNEL_CFGRTR_DIR)/h4acfg-$(ARCH_NAME)
@@ -49,7 +52,7 @@ LINK_SCRIPT = link.lds
 
 
 # %jp{パス設定}%en{add source directories}
-INC_DIRS += . ..
+INC_DIRS += . .. $(INC_PROC_DIR)
 SRC_DIRS += . ..
 
 

--- a/sample/ia32/pcat/ostimer.c
+++ b/sample/ia32/pcat/ostimer.c
@@ -11,6 +11,7 @@
 
 #include "kernel.h"
 #include "ostimer.h"
+#include "proc.h"
 
 
 


### PR DESCRIPTION
IA32ポートの軽微なバグフィックスを行いました

* ワード長I/O出力処理の誤りを修正.
* プロセッサヘッダファイルのインクルード方法の修正
* QEmuによる実行 Makefile ターゲット (make qemu)を追加