### PR TITLE
修正概要: Microblaze をアップストリーム版gccでコンパイル可能にするための修正。

### DIFF
--- a/kernel/build/common/gmake/gcc_d.inc
+++ b/kernel/build/common/gmake/gcc_d.inc
@@ -13,7 +13,7 @@ CMD_ASM    ?= gcc
 CMD_LIBR   ?= ar
 CMD_LINK   ?= gcc
 CMD_OBJCNV ?= objcopy
-
+CMD_OBJDUMP ?= objdump
 
 # %jp{拡張子定義}%en{file extensions}
 EXT_C   ?= c

--- a/kernel/source/arch/proc/mb/mb_v8/gcc/kexc_hdr.S
+++ b/kernel/source/arch/proc/mb/mb_v8/gcc/kexc_hdr.S
@@ -5,6 +5,8 @@
 /*                                  http://sourceforge.jp/projects/hos/     */
 /* ------------------------------------------------------------------------ */
 
+/*  %jp{例外番号マスク}                 */
+#define ESR_EXC_MASK            0x0000001F
 
 				.global	_kernel_exc_hdr
 				.global	_kernel_exe_exc
@@ -31,12 +33,18 @@ _kernel_exc_hdr:
 				swi		r10, r1, 32
 				swi		r11, r1, 36
 				swi		r12, r1, 40
-				
-				
-		/* ---- 例外処理実行処理呼び出し */
-				brlid	r15, _kernel_exe_exc
+
+		/* ---- %jp{例外番号を第1引数(r5)に設定} */
+				mfs		r5, resr
+				andi	r5, r5, ESR_EXC_MASK;
+
+		/* ---- %jp{拡張情報(例外コンテキスト)を第2引数(r6)に設定} */
+				addik   r6, r1, 0
+
+		/* ---- %jp{例外ハンドラ実行, r5:例外番号, r6:拡張情報(例外コンテキスト)} */
+				brlid	r15, _kernel_exe_exh
 				addik	r3, r0, 0
-				
+
 		/* ---- レジスタ復帰 */
 				lwi		r15, r1, 0
 				lwi		r3, r1, 4

--- a/sample/mb/mb_v8_axi/gcc/Makefile
+++ b/sample/mb/mb_v8_axi/gcc/Makefile
@@ -5,7 +5,8 @@
 # http://sourceforge.jp/projects/hos/
 # ----------------------------------------------------------------------------
 
-
+# KERNEL_DEBUG ?= Yes
+# DEBUG        ?= Yes
 
 # --------------------------------------
 #  %jp{各種設定}{setting}
@@ -58,8 +59,8 @@ SRC_DIRS += . ..
 # %jp{オプションフラグ}%en{option flags}
 AFLAGS  = -mcpu=v8.00.a -mlittle-endian
 CFLAGS  = -mcpu=v8.00.a -mlittle-endian
-LNFLAGS = -mcpu=v8.00.a -mlittle-endian -nostartfiles -Wl,-Map,$(TARGET).map,-T$(LINK_SCRIPT)
-
+LNFLAGS = -mcpu=v8.00.a -mlittle-endian -nostdlib -nostartfiles -Wl,-Map,$(TARGET).map,-T$(LINK_SCRIPT)
+LNFLAGS2 = -lgcc
 
 # %jp{コンパイラ依存の設定読込み}%en{compiler dependent definitions}
 include $(KERNEL_MAKINC_DIR)/$(ARCH_CC)_d.inc
@@ -146,4 +147,3 @@ $(OBJS_DIR)/sample.$(EXT_OBJ) : ../kernel_id.h
 
 
 # end of file
-

--- a/sample/mb/smm/gcc/Makefile
+++ b/sample/mb/smm/gcc/Makefile
@@ -5,7 +5,11 @@
 # http://sourceforge.jp/projects/hos/
 # ----------------------------------------------------------------------------
 
+# KERNEL_DEBUG ?= Yes
+# DEBUG        ?= Yes
 
+# data2memを使用したデータ変換の実施
+MB_NEED_DATA_TRANSLATION ?= Yes
 
 # --------------------------------------
 #  %jp{各種設定}{setting}
@@ -21,7 +25,7 @@ CMD_CC     ?= $(GCC_ARCH)gcc
 CMD_ASM    ?= $(GCC_ARCH)gcc
 CMD_LINK   ?= $(GCC_ARCH)gcc
 CMD_OBJCNV ?= $(GCC_ARCH)objcopy
-
+CMD_OBJDUMP ?= $(GCC_ARCH)objdump
 
 # %jp{アーキテクチャ定義}%en{architecture}
 ARCH_NAME ?= mb_v8
@@ -58,7 +62,8 @@ SRC_DIRS += . ..
 # %jp{オプションフラグ}%en{option flags}
 AFLAGS  = -mcpu=v7.30.a -mbig-endian -mno-xl-soft-mul
 CFLAGS  = -mcpu=v7.30.a -mbig-endian -mno-xl-soft-mul
-LNFLAGS = -mcpu=v7.30.a -mbig-endian -nostartfiles -Wl,-Map,$(TARGET).map,-T$(LINK_SCRIPT)
+LNFLAGS = -mcpu=v7.30.a -mbig-endian -nostdlib -nostartfiles -Wl,-Map,$(TARGET).map,-T$(LINK_SCRIPT)
+LNFLAGS2 = -lgcc
 
 
 # %jp{コンパイラ依存の設定読込み}%en{compiler dependent definitions}
@@ -101,10 +106,16 @@ CSRCS += ../ostimer.c
 # %jp{ALL}%en{all}
 .PHONY : all
 all: kernel_make makeexe_all $(TARGET_EXE) $(TARGET_MOT) $(TARGET_HEX) $(TARGET_BIN) $(TARGET_V)
-	mb-objdump -D $(TARGET_EXE) > $(TARGET).dis
+	$(CMD_OBJDUMP) -D $(TARGET_EXE) > $(TARGET).dis
 
 $(TARGET_V) : $(TARGET_EXE)
+# %jp{data2memを用いたデータ変換}
+ifeq ($(MB_NEED_DATA_TRANSLATION),Yes)
 	data2mem.exe -bm smm.bmm -bd $(TARGET_EXE) -o v $(TARGET_V)
+else
+	:
+endif
+
 
 # %jp{クリーン}%en{clean}
 .PHONY : clean
@@ -150,4 +161,3 @@ $(OBJS_DIR)/sample.$(EXT_OBJ) : ../kernel_id.h
 
 
 # end of file
-


### PR DESCRIPTION
すみません、不要なコミットが混じってしまっていたので出し直します。
XilinxSDKのgccが内環境(アップストリーム版のgcc環境)で, Microblazeターゲットをコンパイルするための修正を作りました。

 - 標準ライブラリをリンクしないようにするオプション(`-nostdlib`)を追加
   `-nostdlib`がついていない場合, XilinxSDKが提供するlibxilをリンクするため。
   修正対象ファイル: sample/mb/smm/gcc/Makefile,sample/mb/mb_v8_axi/gcc/Makefile

- libgccをリンクするためのオプションを`LNFLAGS2`に設定
  修正対象ファイル: sample/mb/smm/gcc/Makefile,sample/mb/mb_v8_axi/gcc/Makefile

- objdumpコマンドの定義(CMD_OBJDUMP)をプロセッサ共通のカーネルMakefileとsmmターゲット用のMakefileに追加
   修正対象ファイル: kernel/build/common/gmake/gcc_d.inc, sample/mb/smm/gcc/Makefile

- デバッグシンボル付きでコンパイルするための定義をコメントで追加(mb_v8_axiに合わせた)
   修正対象ファイル: sample/mb/smm/gcc/Makefile

- XilinxSDKが提供するdata2memを使用したデータ変換の実施有無を制御するMakefile変数を導入(挙動の互換性のため, デフォルトはYesに設定)
    修正対象ファイル: sample/mb/smm/gcc/Makefile