### PR TITLE
修正概要: GPレジスタの初期化手順の誤りを修正

### DIFF
--- a/sample/riscv/virt/gcc/ram.lds.in
+++ b/sample/riscv/virt/gcc/ram.lds.in
@@ -36,7 +36,7 @@ SECTIONS
 		. = ALIGN(16);
 		___data = . ;
 		*(.data)
-		_gp = ALIGN(16) + 0x7ff0;
+		_gp = ALIGN(16) + 0x800;
 		*(.sdata)
 		___data_end = . ;
 	} > ram


### PR DESCRIPTION
MIPSと異なり, RISC-Vの場合, GPレジスタが指し示す.sdataセクションの大きさは4KiBです。
 .sdataセクションの先頭から2KiBのオフセット位置を指し示すようにGPレジスタの初期化処理を修正しました。
